### PR TITLE
BNODE rules should contain an action in all cases

### DIFF
--- a/dom/lgm/ngin/ngin-yacc.y
+++ b/dom/lgm/ngin/ngin-yacc.y
@@ -210,7 +210,7 @@ BndNode:
 														$<bs>$=&BndNode;
 													}
 	BndSpec 										{PutBndNode(&BndNode);}
-	TEND			
+	TEND    										{}
     ;
 BndSpec:
     SurfacePosition									{

--- a/dom/lgm/ngin2d/ngin-yacc.y
+++ b/dom/lgm/ngin2d/ngin-yacc.y
@@ -160,7 +160,7 @@ BndNode:
 														$<bs>$=&BndNode;
 													}
 	BndSpec 										{PutBndNode(&BndNode);}
-	TEND			
+	TEND    										{}
     ;
 BndSpec:
     LinePosition									{


### PR DESCRIPTION
This fixes the "type clash on default action" warning.
