### PR TITLE
Fix up after 493d4d70d9968dc828bcbf29a2a8c9f042634827

### DIFF
--- a/m4/system_heap.m4
+++ b/m4/system_heap.m4
@@ -11,7 +11,7 @@ dnl No way to know without measuring.
 
 AC_DEFUN([UG_ENABLE_SYSTEM_HEAP],[
   AC_ARG_ENABLE(system-heap,
-    AS_HELP_STRING([--disable-system-heap],[If this is set, UG's own heap data structure is used instead of the operating system heap.], [], [enable_system_heap=yes]))
+    AS_HELP_STRING([--disable-system-heap],[If this is set, UG's own heap data structure is used instead of the operating system heap.]), [], [enable_system_heap=yes])
 
   AS_IF([test "x$enable_system_heap" = "xyes"],
     AC_DEFINE(UG_USE_SYSTEM_HEAP, 1, [If this is set, the operating system heap is used instead of UG's own heap data structure.]))


### PR DESCRIPTION
As a result of 493d4d70d9968dc828bcbf29a2a8c9f042634827, `autoreconf` fails to run. Arguments that are supposed to be passed to `AC_ARG_ENABLE` were erroneously passed to `AS_HELP_STRING` instead.
